### PR TITLE
Fix - Corrige a precedência de operadores no parser

### DIFF
--- a/src/parser.py
+++ b/src/parser.py
@@ -139,8 +139,17 @@ class Parser:
         return Enquanto(condicao, bloco)
 
     def expressao(self) -> ASTNode:
+        node = self.expressao_soma()
+        if self.token_atual and self.token_atual.tipo == 'OP_RELACIONAL':
+            op = self.token_atual
+            self._avancar()
+            dir = self.expressao_soma()
+            node = BinOp(esq=node, op=op, dir=dir)
+        return node
+
+    def expressao_soma(self) -> ASTNode:
         node = self.termo()
-        while self.token_atual and self.token_atual.tipo in ('OP_ARITMETICO', 'OP_RELACIONAL'):
+        while self.token_atual and self.token_atual.tipo == 'OP_ARITMETICO':
             op = self.token_atual
             self._avancar()
             dir = self.termo()

--- a/tests/entrada_precedencia_falha.txt
+++ b/tests/entrada_precedencia_falha.txt
@@ -1,0 +1,16 @@
+inicio
+    // Este teste foi projetado para expor a falha na precedência
+    // de operadores. A expressão "10 > 3 + 8" é o ponto chave.
+    // O parser deve interpretar como 10 > (3 + 8),
+    // que resulta em 10 > 11, avaliado como 'falso'.
+
+    var texto: cor_fundo;
+    cor_fundo = "white";
+
+    se 10 > 3 + 8 entao
+        cor_de_fundo "red";
+    senao
+        cor_de_fundo "green";
+    fim_se;
+
+fim


### PR DESCRIPTION
A análise de expressão foi refatorada para garantir que operadores aritméticos (+, -, *, /) sejam avaliados antes dos operadores relacionais (>, <, ==).

Isso corrige a falha onde `10 > 3 + 8` era interpretado incorretamente como `(10 > 3) + 8`.